### PR TITLE
Switch to Altis for get_aws_sdk

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -197,10 +197,10 @@ function get_items( string $previous_item = null, array $eq_filters = [], int $f
 	if ( $previous_item ) {
 		$query['ExclusiveStartKey'] = [
 			'Id' => [
-				'S' => $previous_item
+				'S' => $previous_item,
 			],
 			'Site_Id' => [
-				'N' => (string) get_current_blog_id()
+				'N' => (string) get_current_blog_id(),
 			],
 		];
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -3,7 +3,7 @@
 namespace HM\Platform\Audit_Log;
 
 use Exception;
-use function HM\Platform\get_aws_sdk;
+use function Altis\get_aws_sdk;
 use WP_Error;
 
 function bootstrap() {


### PR DESCRIPTION
This is needed as Audit Log is only used on Vantage-backend and we switched it to use Altis